### PR TITLE
fix(auth)!: Ensure tokens are valid immediately after being issued.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
                 "eslint": "^9.8.0",
                 "eslint-plugin-react": "^7.35.0",
                 "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-                "eslint-plugin-react-refresh": "^0.4.9",
+                "eslint-plugin-react-refresh": "^0.4.20",
                 "globals": "^15.9.0",
                 "jsdom": "^24.1.1",
                 "vite": "^6.2.2",
@@ -3482,13 +3482,13 @@
             }
         },
         "node_modules/eslint-plugin-react-refresh": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz",
-            "integrity": "sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==",
+            "version": "0.4.20",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.20.tgz",
+            "integrity": "sha512-XpbHQ2q5gUF8BGOX4dHe+71qoirYMhApEPZ7sfhF/dNnOF1UXnCMGZf79SFTBO7Bz5YEIT4TMieSlJBWhP9WBA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "eslint": ">=7"
+                "eslint": ">=8.40"
             }
         },
         "node_modules/eslint-scope": {
@@ -3723,6 +3723,21 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+            "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/file-entry-cache": {
@@ -5163,6 +5178,19 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "license": "ISC"
         },
+        "node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -5938,6 +5966,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
         "node_modules/tinypool": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
@@ -6166,15 +6211,18 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.2.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-            "integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+            "version": "6.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
                 "postcss": "^8.5.3",
-                "rollup": "^4.30.1"
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
             },
             "bin": {
                 "vite": "bin/vite.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
         "eslint": "^9.8.0",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
-        "eslint-plugin-react-refresh": "^0.4.9",
+        "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^15.9.0",
         "jsdom": "^24.1.1",
         "vite": "^6.2.2",

--- a/frontend/src/Pages/LoginPage/LoginPage.jsx
+++ b/frontend/src/Pages/LoginPage/LoginPage.jsx
@@ -13,10 +13,10 @@ export const LoginPage = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (token) {
+    if (isAuthenticated) {
       navigate("/animals")
     } 
-  }, [token]);
+  }, [isAuthenticated]);
 
 
   const handleEmailChange = (event) => {

--- a/frontend/src/components/Context/AuthProvider.jsx
+++ b/frontend/src/components/Context/AuthProvider.jsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, createContext, useContext } from "react";
-import { loginService, logoutService, refreshToken, signupService } from "../../services/authService"
+import {
+  loginService,
+  logoutService,
+  refreshToken,
+  signupService,
+} from "../../services/authService";
 import { jwtDecode } from "jwt-decode";
-
 
 const AuthContext = createContext(null);
 
@@ -9,187 +13,158 @@ const AuthProvider = ({ children }) => {
   const [token, setToken] = useState();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false); 
+  const [refreshing, setRefreshing] = useState(false);
 
-  const isTokenExpired = (token) => {
+  // initAuth will run on mount
+  useEffect(() => {
+    const initAuth = async () => {
+      try {
+        console.log('useEffect attempt to refresh token')
+        await handleRefreshToken();
+      } catch (error) {
+        console.error("Failed to initialize auth", error);
+        setIsAuthenticated(false);
+      } finally {
+        setIsLoading(false);
+        console.log("initAuth has finished");
+      }
+    };
+
+    initAuth();
+  }, []);
+
+  const isTokenExpired = async (token) => {
     // if there isn't a token, return true
-    if (!token) return true
+    if (!token) return true;
     try {
-    // if there is a token, decode the token and check whether it has expired (30 seconds or less left)
+      // if there is a token, decode the token and check whether it has expired (30 seconds or less left)
       const decoded = jwtDecode(token);
-      return decoded.exp * 1000 < Date.now() - 30000;
+      const isExpired = decoded.exp * 1000 < Date.now() - 30000;
+      return isExpired;
     } catch (error) {
       return true;
     }
-  }
+  };
 
-  // initAuth will run on mount
-useEffect(() => {
-const initAuth = async () => {
-  try {
-    console.log("Initializing auth state...");
-    const data = await refreshToken()
-    if (data && data.token) {
-      
-      console.log("Retrieved token during init")
-      setToken(data.token); // or should be token?
-      setIsAuthenticated(true);
-    }
-    else {
-      console.error("no token data")
-      // setIsAuthenticated(false);
-    }
-  }
-  catch (error) {
-    console.error('Failed to initialize auth', error);
-    setIsAuthenticated(false)
-  }
-  finally {
-    setIsLoading(false)
-    console.log('initAuth has finished')
-  }
-};
+  const handleRefreshToken = async () => {
+    if (refreshing == true) return false;
 
-initAuth()
-
-}, [])
-
-const handleRefreshToken = async () => {
-
-  if (refreshing) return false;
-
-  try {
-    setRefreshing(true)
-    console.log('attempting to refresh token')
-    const data = await refreshToken();
-
-    if (data && data.token) {
-      console.log('token refreshed successfully')
-      setToken(data.token);
-      return true;
-    } else {
-      console.log('token refresh failed - no token returned');
+    try {
+      setRefreshing(true);
+      console.log("attempting to refresh token");
+      const data = await refreshToken();
+      if (data && data.token) {
+        setToken(data.token);
+        setIsAuthenticated(true);
+        const newAccessToken = data.token
+        return newAccessToken;
+      } else {
+        console.error('token refresh failed - no token returned');
+        setIsAuthenticated(false);
+        return false;
+      }
+    } catch (error) {
+      console.error("Token refresh error:", error);
       setIsAuthenticated(false);
-      return false
+      return false;
+    } finally {
+      console.info('refreshing finished')
+      setRefreshing(false);
     }
-  } catch (error) {
-    console.error("Token refresh error:", error);
-    setIsAuthenticated(false);
-    return false;
-  } finally {
-    setRefreshing(false)
-  }
-};
+  };
 
-const handleLogin = async (email, password) => {
-  try {
-    console.log('attempting login...')
-    const data = await loginService(email, password);
-    if (data && data.token) {
-      console.log("Login successful")
-      // console.log(data.token)
-      setToken(data.token)
-      setIsAuthenticated(true);
-      return true
+  const handleLogin = async (email, password) => {
+    try {
+      console.log("attempting login...");
+      const data = await loginService(email, password);
+      if (data && data.token) {
+        setToken(data.token);
+        setIsAuthenticated(true);
+        return true;
+      }
+      return false;
+    } catch (error) {
+      setIsAuthenticated(false);
+      return false;
     }
-    return false
-  } catch (error) {
-    console.error("Login error", error);
-    setIsAuthenticated(false);
-    return false;
-  }
-}
+  };
 
-const handleSignUp = async (formData) => {
-  try {
-    console.log('attempting sign up...')
-    const data = await signupService(formData);
-    if (data && data.token) {
-      console.log("Sign Up successful")
-      setToken(data.token)
-      setIsAuthenticated(true);
-      return true
+  const handleSignUp = async (formData) => {
+    try {
+      console.log("attempting sign up...");
+      const data = await signupService(formData);
+      if (data && data.token) {
+        console.log("Sign Up successful");
+        setToken(data.token);
+        setIsAuthenticated(true);
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error("sign up error", error);
+      setIsAuthenticated(false);
+      return false;
     }
-    return false
-  } catch (error) {
-    console.error("sign up error", error);
-    setIsAuthenticated(false);
-    return false;
-  }
-}
+  };
 
-const handleLogout = async () => {
-  try {
-    console.log("logging out");
-    await logoutService();
-    setToken(null);
-    setIsAuthenticated(false);
-
-    navigate("/login");
-    return true
-  } catch (error) {
-    console.error("Logout error", error)
-    return false;
-  }
-}
-
-
-const authFetch = async(url, options = {}) => {
-  // check if token is expired
-  // if expired -> try to refresh the token
-  // if the token can't be refreshed, get a new token
-  if (isTokenExpired(token)) {
-    console.log("Token expired, attempting refresh before fetch");
-    // refresh the token (handleRefresh token will setToken)
-    await handleRefreshToken();
-   
-  }
-  // make the request using the current token
-  const authOptions = {
-      ...options,
-      headers: {
-        ...options.headers,
-        Authorization: `Bearer ${token}`,
-      },
-    };
-  try {
-    // fetch url passed in, with options passed in AND addition of token
-    const response = await fetch(url, authOptions);
-
-  if (response.status === 401) {
-    console.log("Receved 401 from fetch, attempting token refresh");
-    // attempt to refresh the token if there was an issue (401)
-    const refreshed = await handleRefreshToken();
-
-    // if refreshed is True - update the authHeaders with token
-    if (refreshed) {
-      console.log("token refreshed after 401, retrying fetch");
-      // where am I getting data? data.token
-      console.log('data.token:', token)
-      console.log('refreshed token from state:', token)
-      authOptions.headers.Authorization = `Bearer ${token}`;
-      return fetch(url, authOptions);
-    } else {
-      console.log("Token refresh failed after 401")
-      throw new Error('Session expired');
+  const handleLogout = async () => {
+    try {
+      await logoutService();
+      setToken(null);
+      setIsAuthenticated(false);
+      navigate("/login");
+      return true;
+    } catch (error) {
+      return false;
     }
-  }
-  return response;
-  } catch (error) {
-    console.error("Auth fetch error:", error)
-    throw error;
-}
-  
-} 
+  };
 
-const contextValue = {
+  const authFetch = async (url, options = {}) => {
+    if (isTokenExpired(token) == true) {
+      console.log("Token expired, attempting refresh before fetch");
+      await handleRefreshToken();
+    }
+
+    try {
+      // make the request using the current token
+      const authOptions = {
+        ...options,
+        headers: {
+          ...options.headers,
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      // fetch url passed in, with options passed in AND addition of token
+      const response = await fetch(url, authOptions);
+
+      if (response.status === 401) {
+        console.log("Receved 401 from fetch, attempting token refresh");
+
+        const refreshed_token = await handleRefreshToken();
+        // if refreshed is True - update the authHeaders with token
+        if (refreshed_token) {
+          authOptions.headers.Authorization = `Bearer ${refreshed_token}`;
+          return fetch(url, authOptions);
+        } else {
+          console.log("Token refresh failed after 401");
+          throw new Error("Session expired");
+        }
+      }
+      return response;
+    } catch (error) {
+      console.error("Auth fetch error:", error);
+      throw error;
+    }
+  };
+
+  const contextValue = {
     token,
     isAuthenticated,
     isLoading,
     signup: handleSignUp,
     login: handleLogin,
     logout: handleLogout,
-    authFetch
+    authFetch: authFetch,
   };
 
   return (
@@ -202,9 +177,9 @@ const contextValue = {
 const useAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 };
 
-export { AuthProvider, useAuth};
+export { AuthProvider, useAuth };

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -17,9 +17,18 @@ import { AuthProvider, useAuth } from "../Context/AuthProvider";
 const Navbar = () => {
   const navigate = useNavigate();
   const [loggedIn, setLoggedIn] = useState(false);
-  const { token, logout, isAuthenticated } = useAuth()
+  const { logout, isAuthenticated } = useAuth()
   const [anchorElNav, setAnchorElNav] = useState(null);
   const [anchorElUser, setAnchorElUser] = useState(null);
+
+  useEffect(() => {
+    setLoggedIn(isAuthenticated);
+    console.log('isAuthenticated = ', isAuthenticated)
+  }, [isAuthenticated]);
+
+  const handleLogoutClick = async () => {
+    await logout()
+  };
 
   const handleOpenNavMenu = (event) => {
     setAnchorElNav(event.currentTarget);
@@ -37,19 +46,6 @@ const Navbar = () => {
     setAnchorElUser(null);
   };
 
-  useEffect(() => {
-    setLoggedIn(!!isAuthenticated);
-  }, [token]);
-
-  const handleLogoutClick = async () => {
-    await logout()
-    // if (token) {
-    //   // localStorage.removeItem("token");
-    //   setToken(null);
-    // } 
-    // setLoggedIn(false);
-    // navigate("/login");
-  };
 
   return (
     <AppBar position="static" sx={{ backgroundColor: '#003554' }}>
@@ -99,12 +95,12 @@ const Navbar = () => {
               onClose={handleCloseNavMenu}
               sx={{ display: { xs: "block", md: "none" } }}
             >
-              {/* <MenuItem component={Link} to="/animals" onClick={handleCloseNavMenu}>
+              <MenuItem component={Link} to="/animals" onClick={handleCloseNavMenu}>
                 <Typography textAlign="center">Home</Typography>
               </MenuItem>
               <MenuItem component={Link} to="/animals" onClick={handleCloseNavMenu}>
                 <Typography textAlign="center">Animals</Typography>
-              </MenuItem> */}
+              </MenuItem>
               {!loggedIn && (
                 <Menu>
                   <MenuItem component={Link} to="/sign-up" onClick={handleCloseNavMenu}>

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -88,12 +88,15 @@ export const refreshToken = async () => {
 
   const response = await fetch(`/api/refresh-token`, requestOptions);
   if (response.status !== 200) {
-    if (response.status == 401) throw new Error("Unauthorised");
+    if (response.status == 401) {
+      throw new Error("Unauthorised")
+    }
     else {
-      throw new Error("refresh failed");
+      throw new Error(response.status, ": refresh failed");
     }
   }
 
   const data = await response.json();
   return data;
 };
+

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
       '/api': {
         target: 'http://127.0.0.1:5000',
         changeOrigin: true,
-        reqrite: (path) => path.replace(/^\/api/, '')
+        rewrite: (path) => path.replace(/^\/api/, ''), 
       }
     }
   },

--- a/server/app.py
+++ b/server/app.py
@@ -7,7 +7,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS, cross_origin
 from sqlalchemy import select
 from db.seed import Animal, User, users, animals
-from routes.auth import generate_token, decode_token, token_checker
+from routes.auth import generate_token
 from flask_bcrypt import Bcrypt 
 from lib.database_connection import DatabaseConnection, db
 from routes.animal_routes import animal_bp
@@ -40,8 +40,8 @@ def create_app(test_config=None, instance_relative_config=True, static_folder='s
         # Load the test configuration
         app.config.update(test_config)
     # Register blueprints
-    app.register_blueprint(animal_bp, url_prefix='/api/listings')
-    app.register_blueprint(auth_bp, url_prefix='/api')
+    app.register_blueprint(animal_bp, url_prefix='/listings')
+    app.register_blueprint(auth_bp)
     
     # # Define routes
     
@@ -96,6 +96,14 @@ def seed_db_command():
         db.session.add_all(users)
         click.echo("Database has been seeded")
 
+@click.command()
+@with_appcontext
+def current_time():
+    """Show current UTC unix timestamp"""
+    timestamp = int(time.time())
+    click.echo(f"UTC Unix timestamp: {timestamp}")
+
+app.cli.add_command(current_time)
 app.cli.add_command(init_db_command)
 app.cli.add_command(seed_db_command)
 

--- a/server/lib/database_connection.py
+++ b/server/lib/database_connection.py
@@ -82,6 +82,10 @@ class DatabaseConnection:
         # app.config['UPLOAD_FOLDER'] = 'photo_uploads/images'
         app.config['GOOGLE_APPLICATION_CREDENTIALS'] = Path(app.instance_path) / 'storage-uploader-key.json'
         # app.config['SQLALCHEMY_ECHO'] = True
+        app.config['ACCESS_TOKEN_EXPIRY'] = 900 # 15 minutes
+        app.config['REFRESH_TOKEN_EXPIRY'] = 604800 # 7 days
+        app.config['ACCESS_TOKEN_LEEWAY'] = 60 # 1 minute
+        app.config['REFRESH_TOKEN_LEEWAY'] = 300 # 5 minutes
 
         # intialise SQLAlchemy with app
         db.init_app(app)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -50,6 +50,7 @@ pycparser==2.22
 pydot==3.0.1
 pyparsing==3.1.2
 pytest==8.3.5
+pytest-mock==3.14.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 requests==2.32.3

--- a/server/routes/animal_routes.py
+++ b/server/routes/animal_routes.py
@@ -1,5 +1,5 @@
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, g
 from flask_cors import CORS
 
 from lib.models.animal_repository import AnimalRepository
@@ -38,7 +38,7 @@ def display_one_animal(id):
 @token_checker # Added this decorator to check for token. 
 def create_new_animal():
     data = request.get_json()
-    data['shelter_id']=request.shelter_id
+    data['shelter_id']=g.shelter_id
     animal = animal_repo.create_new_animal(data)
     return jsonify(animal.to_dict()), 201
    
@@ -75,6 +75,7 @@ def create_new_animal():
 @token_checker  # Ensures that the user is authenticated
 def update_animal(id):
     data = request.get_json()
+    print(f"animal data: ${data}")
     animal = animal_repo.update_animal(data)
     if not animal:
         return jsonify({"message": "Animal not found"}), 404

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -5,23 +5,28 @@ import json
 from sqlalchemy import select
 from lib.models import User
 from lib.database_connection import db
+from routes.auth import TokenClaimsRegistry, JWTClaimsRegistry, generate_token, decode_token, validate_token
+from joserfc.errors import *
+from flask import current_app
+
+
 
 def test_valid_login_response( app_ctx,client, db_connection, test_user):
     """When a user logs in with valid credentials, 
     a 200 response should be returned"""
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
     assert response.status_code == 200
     
 def test_incorrect_password_response( app_ctx,client, db_connection, test_user):
     """When a user logs in with an incorrect password, 
     a 401 response should be returned"""
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
     assert response.status_code == 401
     
 def test_incorrect_email_response( app_ctx,client, db_connection, test_user):
     """When a user logs in with an incorrect email, 
     a 401 response should be returned"""
-    response = client.post('api/token', json={"email": "invalid_email@example.com", "password": "V@lidp4ss"})
+    response = client.post('/token', json={"email": "invalid_email@example.com", "password": "V@lidp4ss"})
     assert response.status_code == 401
     
 def test_incorrect_password_error_message( app_ctx,client, db_connection, test_user):
@@ -29,7 +34,7 @@ def test_incorrect_password_error_message( app_ctx,client, db_connection, test_u
     a generic error message should be returned 
     'Email or password is incorrect'
     """
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
     assert response.json['error'] == 'Email or password is incorrect'
     
 def test_incorrect_email_error_message( app_ctx,client, db_connection, test_user):
@@ -37,41 +42,41 @@ def test_incorrect_email_error_message( app_ctx,client, db_connection, test_user
     a generic error message should be returned 
     'Email or password is incorrect'
     """
-    response = client.post('api/token', json={"email": "invalid_email@example.com", "password": "V@lidp4ss"})
+    response = client.post('/token', json={"email": "invalid_email@example.com", "password": "V@lidp4ss"})
     assert response.json['error'] == 'Email or password is incorrect'
     
 def test_valid_login_returns_token(app_ctx, client, db_connection, test_user):
     """When a user logs in with valid credentials, a token should be returned"""
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
     assert 'token' in response.json
 
 def test_invalid_login_doesnt_return_token(app_ctx, client, db_connection, test_user):
     "when a user attempts login with invalid credentials, there shouldn't be a token in the response"
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "inV@lidp4ss"})
     assert 'token' not in response.json
     assert response.status_code == 401
     
 def test_nonexistant_user_doesnt_return_token(app_ctx, client, db_connection, test_user):
     "when a non-existant user attempts login, there shouldn't be a token in the response"
-    response = client.post('api/token', json={"email": "idontexist@example.com", "password": "inV@lidp4ss"})
+    response = client.post('/token', json={"email": "idontexist@example.com", "password": "inV@lidp4ss"})
     assert 'token' not in response.json
     assert response.status_code == 401
     
 def test_valid_login_returns_token(app_ctx, client, db_connection, test_user):
     """When a user logs in with valid credentials, a token should be returned"""
-    response = client.post('api/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
+    response = client.post('/token', json={"email": "Unique_test1@example.com", "password": "V@lidp4ss"})
     assert 'token' in response.json
     
 def test_protected_route_with_valid_token(client, db_connection, test_user):
     """Test accessing a protected route with a valid token"""
-    response = client.post('api/token', json={
+    response = client.post('/token', json={
         'email':test_user.email,
         'password':'V@lidp4ss'
     })
     
     token = response.json['token']
 
-    response = client.get('api/protected', headers={
+    response = client.get('/protected', headers={
         'Authorization': f'Bearer {token}'
     })
     
@@ -79,21 +84,21 @@ def test_protected_route_with_valid_token(client, db_connection, test_user):
 
 def test_protected_route_without_token(client, db_connection):
     """Test accessing a protected route without a token"""
-    response = client.get('api/protected')
+    response = client.get('/protected')
     assert response.status_code == 401
     assert response.json['message'] == 'Token is missing!'
 
 def test_protected_route_with_invalid_token(client):
     invalid_token = 'ezJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJwYXdzZm9yYWNhdXNlIiwic3ViIjoiVW5pcXVlX3Rlc3QxQGV4YW1wbGUuY29tIiwiaWF0IjoxNzQzNjAyMzA3LCJleHAiOjE3NDM2MDU5MDcsImlkIjoxLCJzaGVsdGVyX2lkIjoxfQ.Misuk7gFhRWIXIC7pZRfgm9oKczFXBO2kkkkkKeYZ1_OM8FylPFvVqMk1dou_Z6V_h7LsRtBnmscxMeStAVhBUqDfUQOJkDDmqTXODRGgm-Xc7NUQM4LLQ5QQJMKsMUVVvpxV6_XkjN5R6BzhKp3KGew9eK1tQAIwHP_09hRD9y6WEqer2R5VJtUpPb9wMY9WcHg30mWIOqbTXHhjsv-ay572-LRz2mHgmWC5EsrfpcaWxiJQmYpWYiQCTcKD0wuPvYh53f-JOY1fIoXkW7YCQ'
     """Test accessing a protected route with an invalid token"""
-    response = client.get('api/protected', headers={
+    response = client.get('/protected', headers={
         'Authorization': f'Bearer {invalid_token}'
     })
     assert response.status_code == 401
 
 def test_token_can_be_decoded_with_public_key(app_ctx, client, db_connection, test_user):
     """Test that a token can be decoded with the public key"""
-    response = client.post('api/token', json={
+    response = client.post('/token', json={
         'email': test_user.email,
         'password':'V@lidp4ss'
     })
@@ -104,29 +109,177 @@ def test_token_can_be_decoded_with_public_key(app_ctx, client, db_connection, te
     
     # Assert the token was decoded successfully
     assert decoded is not None
-    assert decoded.claims.get('sub') == test_user.email
-    assert decoded.claims.get('id') == test_user.id
+    assert decoded.claims.get('sub') == test_user.id
+   
     
-
-def test_expired_token_is_rejected(app_ctx, client, db_connection, test_user, mocker):  
-    mocker.patch('routes.auth.time.time', return_value=1743521149)
-    response = client.post('api/token', json={
+def test_token_is_access_token(app_ctx, client, db_connection, test_user):
+    """Test that a token can be decoded with the public key"""
+    response = client.post('/token', json={
         'email': test_user.email,
-        'password': 'V@lidp4ss'
+        'password':'V@lidp4ss'
     })
     token = response.json['token']
     
+    from routes.auth import decode_token
+    decoded = decode_token(token)
+    print(f"token_type: {decoded.claims.get('token_type')}")
+    # Assert the token was decoded successfully
+    assert decoded is not None
+    assert decoded.claims.get('token_type') == 'access'
+
+def test_token_claims_registry_valid_claims(app_ctx,db_connection, mocker):
+    """
+    TokenClaimsRegistry should validate correctly formed access token claims
+    """
+    token_leeway = current_app.config['ACCESS_TOKEN_EXPIRY']
+    token_claims_registry = TokenClaimsRegistry(leeway=token_leeway)
+    current_time = int(time.time())
+    expiry = current_app.config['ACCESS_TOKEN_EXPIRY']
     
-    response = client.get('api/protected', headers={
+    valid_claims = {
+        "iss": "pawsforacause",
+        "sub": "test_user@example.com",
+        "iat": current_time,
+        "exp": current_time + expiry,
+        "token_type": "access"
+    }
+   
+    mock_super_validate = mocker.patch.object(JWTClaimsRegistry, 'validate', return_value=None)
+    
+    result = token_claims_registry.validate(valid_claims)
+    
+    assert result is None 
+    mock_super_validate.assert_called_once_with(valid_claims)
+
+
+# def test_token_claims_registry_invalid_token_type(app_ctx,db_connection,mocker):
+#     """
+#     Should raise ValueError when token type is not valid
+#     """
+    
+#     invalid_claims = {
+#         "iss": "pawsforacause", 
+#         "token_type": "pretend" 
+#     }
+    
+#     with pytest.raises(ValueError) as err:
+#         token_claims_registry.validate(invalid_claims)
+#     error_message = str(err.value)
+#     print(error_message)
+#     assert error_message == "token_type isn't valid"
+
+    
+def test_token_claims_registry_iat_not_yet_valid(app_ctx,db_connection,mocker):
+    """
+    Should raise InvalidTokenError when iat is in the future
+    """
+    token_leeway = current_app.config['ACCESS_TOKEN_EXPIRY']
+    token_claims_registry = TokenClaimsRegistry(leeway=token_leeway)
+    current_time = int(time.time())
+    
+    invalid_claims = {
+        "iss": "pawsforacause", 
+        "token_type": "access",
+        "iat": current_time + 30000,
+    }
+    
+    with pytest.raises(InvalidTokenError) as err:
+        token_claims_registry.validate(invalid_claims)
+    error_message = str(err.value.description)
+    assert error_message == 'The token is not valid yet'
+    
+def test_token_claims_registry_exp_invalid(app_ctx,db_connection,mocker):
+    """
+    Should raise InvalidTokenError when 'exp' is in the past
+    """
+    
+    token_leeway = current_app.config['ACCESS_TOKEN_EXPIRY']
+    token_claims_registry = TokenClaimsRegistry(leeway=token_leeway)
+    # mocker.patch('routes.auth.time.time', return_value=1743521149)
+    
+    invalid_claims = {
+        "iss": "pawsforacause", 
+        "token_type": "access",
+        "exp": 1743521149,
+    }
+    
+    with pytest.raises(ExpiredTokenError) as err:
+        token_claims_registry.validate(invalid_claims)
+    error_message = str(err.value)
+    print(error_message)
+    assert error_message == 'expired_token: The token is expired'
+    
+def test_token_claims_registry_iat_is_valid(app_ctx,db_connection):
+    """
+    Should return None when 'iat' time is in the past
+    """
+    
+    token_leeway = current_app.config['ACCESS_TOKEN_EXPIRY']
+    token_claims_registry = TokenClaimsRegistry(leeway=token_leeway)
+    current_time = int(time.time())
+    
+    valid_claims = {
+        "iss": "pawsforacause", 
+        "token_type": "access",
+        "iat": current_time,
+    }
+    
+    response = token_claims_registry.validate_iat(valid_claims.get('iat'))
+    print(response)
+    assert response == None
+    
+def test_token_claims_registry_invalid_issuer(app_ctx,db_connection,mocker):
+    """
+    Should raise ValueError when issuer is not 'pawsforacause'
+    """
+    token_leeway = current_app.config['ACCESS_TOKEN_EXPIRY']
+    token_claims_registry = TokenClaimsRegistry(leeway=token_leeway)
+    
+    invalid_claims = {
+        "iss": "notpawsforacause", 
+        "token_type": "access" 
+    }
+    
+    with pytest.raises(ValueError) as err:
+        token_claims_registry.validate(invalid_claims)
+    error_message = str(err.value)
+    print(error_message)
+    assert error_message == "Issuer isn't valid!"
+        
+
+def test_valid_access_token_result_is_true(app_ctx,client, db_connection, test_user, mocker):
+    """
+    validate_token should return True for a valid access token
+    """
+    
+    token = generate_token(test_user.id)
+    decoded = decode_token(token)
+    claims = decoded.claims
+    result = validate_token(claims)
+    assert result == None
+
+def test_expired_token_is_rejected(app_ctx, client, db_connection, test_user, mocker):  
+    mocker.patch('routes.auth.time.time', return_value=1743521149)
+    token_response = client.post('/token', json={
+        'email': test_user.email,
+        'password': 'V@lidp4ss'
+    })
+    token = token_response.json['token']
+    print(f"token = {token}")
+    mocker.patch('routes.auth.time.time', return_value=1743523049)
+    print(f" the time now is: {time.time()}")
+    
+    response = client.get('/protected', headers={
         'Authorization': f'Bearer {token}'
     })
+    print(response.json['message'] )
     
     assert response.status_code == 401
-    assert response.json['message'] == 'Invalid or expired token!'
+    assert response.json['message'] == 'expired_token: The token is expired'
     
 def test_logout_removes_token(app_ctx, client, db_connection, test_user, mocker):  
     
-    response = client.post('api/logout')
+    response = client.post('/logout')
     
     cookie_header = response.headers.get('Set-Cookie')
     print(cookie_header)
@@ -135,3 +288,4 @@ def test_logout_removes_token(app_ctx, client, db_connection, test_user, mocker)
     assert 'refresh_token=' in cookie_header
     assert 'Max-Age=0' in cookie_header or 'Expires=' in cookie_header
     assert response.json['message'] == 'logged out successfully'
+    


### PR DESCRIPTION
- (Authprovider) refactor initAuth to use handleRefreshToken as this already handles setting token state
- (Authprovider) explicitly check if isTokenExpired returns 'true' in authFetch to avoid an issue if the returned value is truthy
- (Authprovider) pass authFetch correctly as 'authFetch: authFetch' in the contextValue
- (Navbar) set 'logged in' state based on state of 'isAuthenticated'
- (LoginPage) useEffect state updates based on 'isAuthenticated' state instead of 'token', ensures user isn't authenticated with an invalid token
- (app.py) remove '/api' url prefix from blueprints as this is already present in vite proxy config
- (app.py) add current_time click command for debugging (can be removed later if not needed)
- (database connection) add token expiry and leeway values to config for reusability, prevent using 'magic numbers' in app
- (auth_repository) pass the user.id in 'sub' token claims, instead of users email
- (auth_repository) add refresh token rotation to get_access_token function in line with current oAuth security best practices.
- (animal_routes) use flask 'g' library in favour of 'request'
- (auth.py) addition of TokenClaimsRegistry that takes an instance of JWTClaimsRegistry in line with joserfc jwt api docs
- (auth.py)remove validation logic from decode and add a validate_token function for separation of concerns, ensures decode only handles decoding and validate only handles validation
- (auth.py) decode now takes algorithms keyword to ensure rs256 algorithm is used for validation
- (auth.py) validate token takes leeway based on leeway config and makes use of JWTClaimsRegistry inbuilt validate_iat and validate_exp
- (auth.py) generate_token takes expiry from app config based on token type. expiry_time variable added.
- (auth.py) remove logic in token_checker wrapper that is handled already by functions to streamline function calls. Exceptions now 'bubble up' through the call stack so errors are clearer.
- (test_auth) more tests added for token auth

BREAKING CHANGE: Create animal requires use of new update_request_data function